### PR TITLE
Fixed a typing error

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You'll only need the Bash shell:
 
 - [Exercise 1](./exercises/exercise-1.md/) - Getting started
 - [Exercise 2](./exercises/exercise-2.md/) - Basics of the shell
-- [Exercise 2](./exercises/exercise-3.md/) - Scripting
+- [Exercise 3](./exercises/exercise-3.md/) - Scripting
 - [Exercise 4](./exercises/exercise-4.md/) - Using pipelines and redirects
 - [Exercise 5](./exercises/exercise-5.md/) - Number guessing game
 


### PR DESCRIPTION
Was reading through and saw a typing error, saying "Exercise 2" instead of "Exercise 3".